### PR TITLE
Add Russian site at /ru and replace root with temporary closed notice

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,143 +1,58 @@
-<html><head><meta content="text/html; charset=UTF-8" http-equiv="content-type"><style type="text/css">@import url(https://themes.googleusercontent.com/fonts/css?kit=fpjTOVmNbO4Lz34iLyptLSGpxL_7AiMlXksihSwXLVVUY4CRT7JNLdKN7yejUsjr);.lst-kix_list_2-6>li:before{content:"\0025cf   "}.lst-kix_list_2-7>li:before{content:"o  "}ul.lst-kix_list_1-0{list-style-type:none}.lst-kix_list_2-4>li:before{content:"o  "}.lst-kix_list_2-5>li:before{content:"\0025aa   "}.lst-kix_list_2-8>li:before{content:"\0025aa   "}ul.lst-kix_list_2-8{list-style-type:none}ul.lst-kix_list_1-3{list-style-type:none}ul.lst-kix_list_2-2{list-style-type:none}.lst-kix_list_1-0>li:before{content:"\0025cf   "}ul.lst-kix_list_1-4{list-style-type:none}ul.lst-kix_list_2-3{list-style-type:none}ul.lst-kix_list_1-1{list-style-type:none}ul.lst-kix_list_2-0{list-style-type:none}ul.lst-kix_list_1-2{list-style-type:none}ul.lst-kix_list_2-1{list-style-type:none}ul.lst-kix_list_1-7{list-style-type:none}ul.lst-kix_list_2-6{list-style-type:none}.lst-kix_list_1-1>li:before{content:"o  "}.lst-kix_list_1-2>li:before{content:"\0025aa   "}ul.lst-kix_list_1-8{list-style-type:none}ul.lst-kix_list_2-7{list-style-type:none}ul.lst-kix_list_1-5{list-style-type:none}ul.lst-kix_list_2-4{list-style-type:none}ul.lst-kix_list_1-6{list-style-type:none}ul.lst-kix_list_2-5{list-style-type:none}.lst-kix_list_1-3>li:before{content:"\0025cf   "}.lst-kix_list_1-4>li:before{content:"o  "}.lst-kix_list_1-7>li:before{content:"o  "}.lst-kix_list_1-5>li:before{content:"\0025aa   "}.lst-kix_list_1-6>li:before{content:"\0025cf   "}li.li-bullet-0:before{margin-left:-18pt;white-space:nowrap;display:inline-block;min-width:18pt}.lst-kix_list_2-0>li:before{content:"\0025cf   "}.lst-kix_list_2-1>li:before{content:"o  "}.lst-kix_list_1-8>li:before{content:"\0025aa   "}.lst-kix_list_2-2>li:before{content:"\0025aa   "}.lst-kix_list_2-3>li:before{content:"\0025cf   "}ol{margin:0;padding:0}table td,table th{padding:0}.c17{margin-left:36pt;padding-top:1pt;padding-left:0pt;padding-bottom:0pt;line-height:1.1500000000000001;orphans:2;widows:2;text-align:justify}.c4{color:#000000;font-weight:400;text-decoration:none;vertical-align:baseline;font-size:10pt;font-family:"Arial";font-style:normal}.c6{-webkit-text-decoration-skip:none;color:#0563c1;font-weight:700;text-decoration:underline;text-decoration-skip-ink:none;font-size:18pt;font-family:"Arial"}.c21{margin-left:36pt;padding-top:1pt;padding-bottom:0pt;line-height:1.1500000000000001;orphans:2;widows:2;text-align:justify}.c26{color:#000000;font-weight:400;text-decoration:none;vertical-align:baseline;font-size:5pt;font-family:"Arial";font-style:italic}.c16{padding-top:1pt;padding-bottom:0pt;line-height:1.1500000000000001;orphans:2;widows:2;text-align:center}.c25{padding-top:0pt;padding-bottom:0pt;line-height:1.0;orphans:2;widows:2;text-align:left}.c1{padding-top:1pt;padding-bottom:0pt;line-height:1.1500000000000001;orphans:2;widows:2;text-align:left}.c34{padding-top:1pt;padding-bottom:0pt;line-height:1.1500000000000001;orphans:2;widows:2;text-align:justify}.c13{color:#000000;text-decoration:none;vertical-align:baseline;font-style:normal}.c31{color:#d5dce4;text-decoration:none;vertical-align:baseline;font-style:normal}.c28{color:#833c0b;text-decoration:none;vertical-align:baseline;font-style:normal}.c15{-webkit-text-decoration-skip:none;color:#0563c1;text-decoration:underline;text-decoration-skip-ink:none}.c8{font-size:9pt;font-family:"Arial";font-style:italic;font-weight:400}.c12{-webkit-text-decoration-skip:none;color:#1155cc;text-decoration:underline;text-decoration-skip-ink:none}.c30{color:#000000;text-decoration:none;vertical-align:baseline}.c19{font-weight:400;font-size:11pt;font-family:"Calibri"}.c9{font-size:12pt;font-weight:700;font-family:"Arial"}.c2{font-size:9pt;font-weight:700;font-family:"Arial"}.c23{font-size:12pt;font-family:"Arial";font-weight:400}.c27{font-weight:400;font-size:12pt;font-family:"Helvetica Neue"}.c24{font-weight:700;font-size:11pt;font-family:"Arial"}.c10{font-size:9pt;font-weight:400;font-family:"Arial"}.c5{font-size:10pt;font-weight:700;font-family:"Arial"}.c11{font-size:10pt;font-weight:400;font-family:"Arial"}.c3{padding:0;margin:0}.c14{color:#19191c;text-decoration:none}.c0{color:inherit;text-decoration:inherit}.c22{max-width:451pt;padding:72pt 72pt 72pt 72pt}.c7{margin-left:36pt;height:11pt}.c32{font-weight:700;font-family:"Arial"}.c33{font-family:"Arial";font-weight:400}.c20{height:11pt}.c29{font-style:italic}.c35{color:#19191c}.c18{background-color:#ffffff}.title{padding-top:24pt;color:#000000;font-weight:700;font-size:36pt;padding-bottom:6pt;font-family:"Calibri";line-height:1.0791666666666666;page-break-after:avoid;orphans:2;widows:2;text-align:left}.subtitle{padding-top:18pt;color:#666666;font-size:24pt;padding-bottom:4pt;font-family:"Georgia";line-height:1.0791666666666666;page-break-after:avoid;font-style:italic;orphans:2;widows:2;text-align:left}li{color:#000000;font-size:11pt;font-family:"Calibri"}p{margin:0;color:#000000;font-size:11pt;font-family:"Calibri"}h1{padding-top:24pt;color:#000000;font-weight:700;font-size:24pt;padding-bottom:6pt;font-family:"Calibri";line-height:1.0791666666666666;page-break-after:avoid;orphans:2;widows:2;text-align:left}h2{padding-top:18pt;color:#000000;font-weight:700;font-size:18pt;padding-bottom:4pt;font-family:"Calibri";line-height:1.0791666666666666;page-break-after:avoid;orphans:2;widows:2;text-align:left}h3{padding-top:14pt;color:#000000;font-weight:700;font-size:14pt;padding-bottom:4pt;font-family:"Calibri";line-height:1.0791666666666666;page-break-after:avoid;orphans:2;widows:2;text-align:left}h4{padding-top:12pt;color:#000000;font-weight:700;font-size:12pt;padding-bottom:2pt;font-family:"Calibri";line-height:1.0791666666666666;page-break-after:avoid;orphans:2;widows:2;text-align:left}h5{padding-top:11pt;color:#000000;font-weight:700;font-size:11pt;padding-bottom:2pt;font-family:"Calibri";line-height:1.0791666666666666;page-break-after:avoid;orphans:2;widows:2;text-align:left}h6{padding-top:10pt;color:#000000;font-weight:700;font-size:10pt;padding-bottom:2pt;font-family:"Calibri";line-height:1.0791666666666666;page-break-after:avoid;orphans:2;widows:2;text-align:left}</style><style>
-  /* --- Layout overrides (added) --- */
-  html, body { height: 100%; }
-  body.doc-body {
-    margin: 0;
-    background: #ffffff;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
-
-  .toolbar {
-    position: sticky;
-    top: 0;
-    z-index: 50;
-    background: #ffffff;
-    border-bottom: 1px solid #e5e7eb;
-    height: 44px;
-    width: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    box-sizing: border-box;
-  }
-  .toolbar-inner {
-    width: 100%;
-    max-width: 180mm;
-    margin: 0 auto;
-    padding: 0 12px;
-    display: flex;
-    justify-content: flex-end;
-    box-sizing: border-box;
-  }
-  .btn {
-    appearance: none;
-    border: 1px solid #d1d5db;
-    background: #ffffff;
-    border-radius: 8px;
-    padding: 8px 12px;
-    font: 600 13px/1 Arial, sans-serif;
-    cursor: pointer;
-  }
-  .btn:hover { background: #f9fafb; }
-  .btn:active { background: #f3f4f6; }
-  .btn:focus { outline: 2px solid #93c5fd; outline-offset: 2px; }
-
-  .experience-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    gap: 12px;
-    padding: 4px 0;
-  }
-  .experience-title {
-    display: inline-flex;
-    flex-wrap: wrap;
-    gap: 4px;
-  }
-  .experience-dates {
-    text-align: right;
-    white-space: nowrap;
-    font-weight: 700;
-  }
-
-
-  .page-container {
-    display: flex;
-    justify-content: center;
-    padding: 16px;
-    box-sizing: border-box;
-    width: 100%;
-    max-width: 180mm;
-    margin: 0 auto;
-  }
-
-  /* Center the document and reduce excessive top padding */
-  .page.c22 {
-    margin: 0 auto;
-    width: 100%;
-    max-width: 180mm;
-    padding: 32px 48px 56px 48px !important;
-    box-sizing: border-box;
-  }
-
-  /* Prevent fixed-width images from overflowing */
-  .page img {
-    max-width: 100% !important;
-    height: auto !important;
-  }
-  /* --- Fix Google Docs exported horizontal line images --- */
-  .doc-content span[style*="overflow: hidden"][style*="display: inline-block"][style*="height:"] {
-    display: block !important;
-    width: 100% !important;
-    max-width: 100% !important;
-    margin: 8px 0 10px 0 !important;
-    line-height: 0 !important;
-  }
-  .doc-content span[style*="overflow: hidden"][style*="display: inline-block"] img {
-    display: block;
-    width: 100% !important;
-    max-width: 100% !important;
-    height: auto !important;
-  }
-
-
-  /* Print / PDF */
-  @media print {
-    body.doc-body { background: #ffffff; }
-    .toolbar { display: none !important; }
-    .page-container { padding: 0 !important; }
-    .page.c22 {
-      box-shadow: none !important;
-      border-radius: 0 !important;
-      padding: 0 !important;
-      max-width: none !important;
-      width: auto !important;
-    }
-    @page { margin: 12mm; }
-  }
-</style>
-</head><body class="doc-body">
-  <header class="toolbar">
-    <div class="toolbar-inner">
-      <button id="downloadPdfBtn" class="btn" type="button">Download as PDF</button>
-    </div>
-  </header>
-
-  <div class="page-container">
-    <div class="page c18 c22 doc-content">
-<div><p class="c20 c25"><span class="c13 c27"></span></p></div><p class="c16"><span class="c6"><a class="c0" href="https://www.google.com/url?q=https://www.linkedin.com/in/timakhovich/&amp;sa=D&amp;source=editors&amp;ust=1767535999415161&amp;usg=AOvVaw1CpvsIJ-HO9pqomKat3NQL">Ivan TIMAKHOVICH</a></span><span class="c9">&nbsp;&mdash; Recruiter</span><span class="c23 c14">, Experience:</span><span class="c9 c14">&nbsp;</span><span class="c9 c35">4+</span><span class="c9 c14">&nbsp;years</span><span class="c14 c23">&nbsp;</span></p><p class="c16"><span class="c10">&nbsp;Alicante, Spain | </span><span class="c12 c10"><a class="c0" href="https://www.google.com/url?q=http://timahovich.com&amp;sa=D&amp;source=editors&amp;ust=1767535999415559&amp;usg=AOvVaw1R1yxUiSNW2fkuhBiwQlKP">timahovich.com</a></span><span class="c10">&nbsp;| </span><span class="c12 c10"><a class="c0" href="mailto:ivan@timahovich.com">ivan@timahovich.com</a></span><span class="c10">&nbsp;</span><span class="c10">| +34(670)293-674 &nbsp;| </span><span class="c10 c12"><a class="c0" href="https://www.google.com/url?q=http://t.me/timahovich&amp;sa=D&amp;source=editors&amp;ust=1767535999415948&amp;usg=AOvVaw1zgCPNMWuSlPJq1c4N0DlW">Telegram</a></span><span class="c10">&nbsp;| </span><span class="c12 c10"><a class="c0" href="https://www.google.com/url?q=https://wa.me/%2B34670293674&amp;sa=D&amp;source=editors&amp;ust=1767535999416090&amp;usg=AOvVaw0JspZj1BoCJwJHhDCC8Ga8">WhatsApp </a></span><span class="c12 c33"><a class="c0" href="https://www.google.com/url?q=http://t.me/Timahovichivan&amp;sa=D&amp;source=editors&amp;ust=1767535999416161&amp;usg=AOvVaw306zBWOe-N8_Eyot1-JD_U">&nbsp;</a></span></p><p class="c16"><span style="overflow: hidden; display: inline-block; margin: 0.00px 0.00px; border: 0.00px solid #000000; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px); width: 602.88px; height: 1.94px;"><img alt="" src="images/image2.png" style="width: 602.88px; height: 1.94px; margin-left: 0.00px; margin-top: 0.00px; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px);" title=""></span></p><p class="c16"><span class="c13 c9 c18">ABOUT</span></p><p class="c34"><span class="c10">Recruiting-focused professional with full-cycle hiring experience (in engineering, design, content and more) and strong stakeholder communication. Built broad technical literacy and developed work-fluent Spanish for day-to-day professional communication. Ready to support high-paced remote hiring at TripleTen.</span><span style="overflow: hidden; display: inline-block; margin: 0.00px 0.00px; border: 0.00px solid #000000; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px); width: 602.88px; height: 1.94px;"><img alt="" src="images/image2.png" style="width: 602.88px; height: 1.94px; margin-left: 0.00px; margin-top: 0.00px; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px);" title=""></span></p><p class="c16"><span class="c13 c9 c18">EXPERIENCE</span></p><div class="experience-header"><span class="experience-title"><span class="c5">Relocation, Upskilling and Internship at </span><span class="c12 c5"><a class="c0" href="https://www.google.com/url?q=https://yeahub.ru/&amp;sa=D&amp;source=editors&amp;ust=1767535999417324&amp;usg=AOvVaw0T7xcGUPhd5T--QsNgQF9X">YeaHub</a></span></span><span class="experience-dates c11">1/2025 &ndash; Current, 1 year</span></div><ul class="c3 lst-kix_list_1-0 start"><li class="c17 li-bullet-0"><span class="c10">Relocated to Spain and adapted to a new professional environment. Developed </span><span class="c2">Spanish to Fluent </span><span class="c10 c13">for day-to-day professional communication and structured calls.</span></li><li class="c17 li-bullet-0"><span class="c10">Built </span><span class="c2">practical technical literacy</span><span class="c13 c10">&nbsp;through a QA internship: backend, frontend, integration testing and issue tracking in Jira &mdash; enabling confident communication with engineers and stronger technical screening.</span></li></ul><p class="c1 c20"><span class="c13 c9"></span></p><div class="experience-header"><span class="experience-title"><span class="c15 c5"><a class="c0" href="https://www.google.com/url?q=https://www.linkedin.com/company/autotelic-council/&amp;sa=D&amp;source=editors&amp;ust=1767535999418458&amp;usg=AOvVaw3vPn8oyxcxIIg1wK3skGRm">Autotelic Council</a></span><span class="c2">&nbsp;Research &amp; Operations</span></span><span class="experience-dates c11">02/2024 &ndash; 12/2024, 11 months</span></div><p class="c1"><span class="c11 c29">Investment holding </span></p><ul class="c3 lst-kix_list_1-0"><li class="c17 li-bullet-0"><span class="c2">Guided onboarding</span><span class="c13 c10">&nbsp;for new team members by coordinating access/tool setup, aligning first-week expectations with stakeholders, and serving as the point of contact to ensure a smooth start.</span></li><li class="c17 li-bullet-0"><span class="c10">Partnered with internal stakeholders to</span><span class="c2">&nbsp;clarify requirements</span><span class="c10">, translate requests into written deliverables, and align priorities across workstreams, contributing, for example, to the development of an AI-powered LMS that reduced lecture time by </span><span class="c2">83.1%</span><span class="c13 c10">.</span></li></ul><p class="c1 c7"><span class="c13 c10"></span></p><div class="experience-header"><span class="experience-title"><span class="c5 c15"><a class="c0" href="https://www.google.com/url?q=https://stakewolle.com/&amp;sa=D&amp;source=editors&amp;ust=1767535999419817&amp;usg=AOvVaw2FhJbPHVJMsKH_SM_oSYJN">Stakewolle</a></span><span class="c2">&nbsp;Team Lead / Founding Ops &amp; Talent Partner</span></span><span class="experience-dates"><span class="c11">05/2022 &ndash; 01/2024, </span><span class="c4">1 year 8 months</span></span></div><p class="c1"><span class="c11 c29">Crypto startup</span></p><ul class="c3 lst-kix_list_2-0 start"><li class="c17 li-bullet-0"><span class="c11">Owned</span><span class="c5">&nbsp;end-to-end hiring</span><span class="c4">&nbsp;for a cross-functional team of 5.</span></li><li class="c17 li-bullet-0"><span class="c11">Built</span><span class="c5">&nbsp;multi-channel sourcing pipelines</span><span class="c4">&nbsp;(job boards, social media, partnerships with online schools), enabling rapid hiring to support product delivery milestones.</span></li><li class="c17 li-bullet-0"><span class="c11">Launched a </span><span class="c5">structured selection process</span><span class="c4">&nbsp;(screening criteria, interview loops, evaluation notes), improving decision speed and quality of hire in a small-team environment.</span></li><li class="c17 li-bullet-0"><span class="c11">Coordinated</span><span class="c5">&nbsp;interview scheduling </span><span class="c4">across time zones and stakeholders, managing calendars, reminders, and timely feedback collection.</span></li><li class="c17 li-bullet-0"><span class="c11">Managed </span><span class="c5">offer process</span><span class="c11">&nbsp;and acceptance. Coordinated </span><span class="c5">onboarding logistics </span><span class="c11">after acceptance (software access, accounts, first-week plan) to ensure a smooth start.<br></span></li></ul><p class="c21"><span class="c11 c29">New hires enabled a website rebuild and launch of gamification functionality, increasing the number of users by 13% in two months after launch.</span></p><p class="c1 c7"><span class="c13 c10"></span></p><div class="experience-header"><span class="experience-title"><span class="c15 c5"><a class="c0" href="https://www.google.com/url?q=https://en.itmo.ru/&amp;sa=D&amp;source=editors&amp;ust=1767535999422589&amp;usg=AOvVaw1rCRLliPf4V9f86J3QxNTY">ITMO University</a></span><span class="c2">&nbsp;Analyst</span></span><span class="experience-dates c11">02/2021 &ndash; 02/2022, 1 year</span></div><p class="c1"><span style="overflow: hidden; display: inline-block; margin: 0.00px 0.00px; border: 0.00px solid #000000; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px); width: 602.88px; height: 0.97px;"><img alt="" src="images/image1.png" style="width: 602.88px; height: 0.97px; margin-left: 0.00px; margin-top: 0.00px; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px);" title=""></span></p><p class="c16"><span class="c9 c18">EDUCATION</span></p><p class="c1"><span class="c15 c2"><a class="c0" href="https://www.google.com/url?q=https://en.itmo.ru/&amp;sa=D&amp;source=editors&amp;ust=1767535999423217&amp;usg=AOvVaw1h-xVjJi4jGUfq--YRDAcD">ITMO University</a></span><span class="c2">&nbsp;| </span><span class="c10">Bachelor&rsquo;s degree, Economics of a High-Tech Business. Top 40 graduates of the year.</span></p><p class="c1"><span class="c8">79th university in the world according to QS World University Rankings by Subject.</span></p><p class="c1 c20"><span class="c13 c19"></span></p><p class="c1"><span class="c15 c2"><a class="c0" href="https://www.google.com/url?q=https://www.edhec.edu/en&amp;sa=D&amp;source=editors&amp;ust=1767535999423800&amp;usg=AOvVaw2NRup9pzPSjzmxLgC_vEYE">EDHEC Business School</a></span><span class="c2">&nbsp;| </span><span class="c13 c10">Exchange Semester, International Business Administration.</span></p><p class="c1"><span class="c8">7th Business School in Europe, according to the Financial Times.</span><span style="overflow: hidden; display: inline-block; margin: 0.00px 0.00px; border: 0.00px solid #000000; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px); width: 602.88px; height: 1.94px;"><img alt="" src="images/image2.png" style="width: 602.88px; height: 1.94px; margin-left: 0.00px; margin-top: 0.00px; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px);" title=""></span></p><p class="c16"><span class="c32">&nbsp;</span><span class="c13 c18 c24">SKILLS</span></p><p class="c1"><span class="c2">Recruiting:</span><span class="c10">&nbsp;Sourcing (job boards, social media, partnerships), Candidate screening, Interview coordination, Structured evaluation/scorecards, Stakeholder alignment (hiring intake), Candidate communication.</span><span class="c13 c2">&nbsp;</span></p><p class="c1"><span class="c2">Software: </span><span class="c10">Confluence, Jira, Calendly, Monday.com, SharePoint, Notion, Trello, Google Docs/Sheets, Excel, Slack, ChatGPT, Claude, Cloudflare, MS Office, GitHub, AI Assistants, Postman, Swagger/OpenAPI, Figma. </span></p><p class="c1"><span class="c2">Languages: </span><span class="c10">English (Fluent, IELTS certification), Spanish (Work Fluent), Russian (Native)</span><span class="c2">.</span></p><div><p class="c25 c20"><span class="c13 c27"></span></p></div>
-    </div>
-  </div>
-
-  <script>
-    (function () {
-      var btn = document.getElementById('downloadPdfBtn');
-      if (!btn) return;
-      btn.addEventListener('click', function () {
-        window.print();
-      });
-    })();
-  </script>
-</body></html>
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Сайт временно закрыт</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Arial", sans-serif;
+        background: #f9fafb;
+        color: #111827;
+        display: flex;
+        min-height: 100vh;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+      }
+      .notice {
+        background: #ffffff;
+        border: 1px solid #e5e7eb;
+        border-radius: 16px;
+        padding: 32px 40px;
+        max-width: 560px;
+        text-align: center;
+        box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+      }
+      h1 {
+        margin: 0 0 12px;
+        font-size: 28px;
+      }
+      p {
+        margin: 0 0 20px;
+        font-size: 16px;
+        line-height: 1.5;
+      }
+      a {
+        display: inline-block;
+        padding: 10px 18px;
+        background: #2563eb;
+        color: #ffffff;
+        text-decoration: none;
+        border-radius: 999px;
+        font-weight: 600;
+      }
+      a:hover {
+        background: #1d4ed8;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="notice">
+      <h1>Основная страница временно закрыта</h1>
+      <p>Сайт сейчас доступен в русской версии. Перейдите по ссылке ниже.</p>
+      <a href="/ru/">Открыть сайт на /ru</a>
+    </main>
+  </body>
+</html>

--- a/ru/index.html
+++ b/ru/index.html
@@ -1,0 +1,143 @@
+<html><head><meta content="text/html; charset=UTF-8" http-equiv="content-type"><style type="text/css">@import url(https://themes.googleusercontent.com/fonts/css?kit=fpjTOVmNbO4Lz34iLyptLSGpxL_7AiMlXksihSwXLVVUY4CRT7JNLdKN7yejUsjr);.lst-kix_list_2-6>li:before{content:"\0025cf   "}.lst-kix_list_2-7>li:before{content:"o  "}ul.lst-kix_list_1-0{list-style-type:none}.lst-kix_list_2-4>li:before{content:"o  "}.lst-kix_list_2-5>li:before{content:"\0025aa   "}.lst-kix_list_2-8>li:before{content:"\0025aa   "}ul.lst-kix_list_2-8{list-style-type:none}ul.lst-kix_list_1-3{list-style-type:none}ul.lst-kix_list_2-2{list-style-type:none}.lst-kix_list_1-0>li:before{content:"\0025cf   "}ul.lst-kix_list_1-4{list-style-type:none}ul.lst-kix_list_2-3{list-style-type:none}ul.lst-kix_list_1-1{list-style-type:none}ul.lst-kix_list_2-0{list-style-type:none}ul.lst-kix_list_1-2{list-style-type:none}ul.lst-kix_list_2-1{list-style-type:none}ul.lst-kix_list_1-7{list-style-type:none}ul.lst-kix_list_2-6{list-style-type:none}.lst-kix_list_1-1>li:before{content:"o  "}.lst-kix_list_1-2>li:before{content:"\0025aa   "}ul.lst-kix_list_1-8{list-style-type:none}ul.lst-kix_list_2-7{list-style-type:none}ul.lst-kix_list_1-5{list-style-type:none}ul.lst-kix_list_2-4{list-style-type:none}ul.lst-kix_list_1-6{list-style-type:none}ul.lst-kix_list_2-5{list-style-type:none}.lst-kix_list_1-3>li:before{content:"\0025cf   "}.lst-kix_list_1-4>li:before{content:"o  "}.lst-kix_list_1-7>li:before{content:"o  "}.lst-kix_list_1-5>li:before{content:"\0025aa   "}.lst-kix_list_1-6>li:before{content:"\0025cf   "}li.li-bullet-0:before{margin-left:-18pt;white-space:nowrap;display:inline-block;min-width:18pt}.lst-kix_list_2-0>li:before{content:"\0025cf   "}.lst-kix_list_2-1>li:before{content:"o  "}.lst-kix_list_1-8>li:before{content:"\0025aa   "}.lst-kix_list_2-2>li:before{content:"\0025aa   "}.lst-kix_list_2-3>li:before{content:"\0025cf   "}ol{margin:0;padding:0}table td,table th{padding:0}.c17{margin-left:36pt;padding-top:1pt;padding-left:0pt;padding-bottom:0pt;line-height:1.1500000000000001;orphans:2;widows:2;text-align:justify}.c4{color:#000000;font-weight:400;text-decoration:none;vertical-align:baseline;font-size:10pt;font-family:"Arial";font-style:normal}.c6{-webkit-text-decoration-skip:none;color:#0563c1;font-weight:700;text-decoration:underline;text-decoration-skip-ink:none;font-size:18pt;font-family:"Arial"}.c21{margin-left:36pt;padding-top:1pt;padding-bottom:0pt;line-height:1.1500000000000001;orphans:2;widows:2;text-align:justify}.c26{color:#000000;font-weight:400;text-decoration:none;vertical-align:baseline;font-size:5pt;font-family:"Arial";font-style:italic}.c16{padding-top:1pt;padding-bottom:0pt;line-height:1.1500000000000001;orphans:2;widows:2;text-align:center}.c25{padding-top:0pt;padding-bottom:0pt;line-height:1.0;orphans:2;widows:2;text-align:left}.c1{padding-top:1pt;padding-bottom:0pt;line-height:1.1500000000000001;orphans:2;widows:2;text-align:left}.c34{padding-top:1pt;padding-bottom:0pt;line-height:1.1500000000000001;orphans:2;widows:2;text-align:justify}.c13{color:#000000;text-decoration:none;vertical-align:baseline;font-style:normal}.c31{color:#d5dce4;text-decoration:none;vertical-align:baseline;font-style:normal}.c28{color:#833c0b;text-decoration:none;vertical-align:baseline;font-style:normal}.c15{-webkit-text-decoration-skip:none;color:#0563c1;text-decoration:underline;text-decoration-skip-ink:none}.c8{font-size:9pt;font-family:"Arial";font-style:italic;font-weight:400}.c12{-webkit-text-decoration-skip:none;color:#1155cc;text-decoration:underline;text-decoration-skip-ink:none}.c30{color:#000000;text-decoration:none;vertical-align:baseline}.c19{font-weight:400;font-size:11pt;font-family:"Calibri"}.c9{font-size:12pt;font-weight:700;font-family:"Arial"}.c2{font-size:9pt;font-weight:700;font-family:"Arial"}.c23{font-size:12pt;font-family:"Arial";font-weight:400}.c27{font-weight:400;font-size:12pt;font-family:"Helvetica Neue"}.c24{font-weight:700;font-size:11pt;font-family:"Arial"}.c10{font-size:9pt;font-weight:400;font-family:"Arial"}.c5{font-size:10pt;font-weight:700;font-family:"Arial"}.c11{font-size:10pt;font-weight:400;font-family:"Arial"}.c3{padding:0;margin:0}.c14{color:#19191c;text-decoration:none}.c0{color:inherit;text-decoration:inherit}.c22{max-width:451pt;padding:72pt 72pt 72pt 72pt}.c7{margin-left:36pt;height:11pt}.c32{font-weight:700;font-family:"Arial"}.c33{font-family:"Arial";font-weight:400}.c20{height:11pt}.c29{font-style:italic}.c35{color:#19191c}.c18{background-color:#ffffff}.title{padding-top:24pt;color:#000000;font-weight:700;font-size:36pt;padding-bottom:6pt;font-family:"Calibri";line-height:1.0791666666666666;page-break-after:avoid;orphans:2;widows:2;text-align:left}.subtitle{padding-top:18pt;color:#666666;font-size:24pt;padding-bottom:4pt;font-family:"Georgia";line-height:1.0791666666666666;page-break-after:avoid;font-style:italic;orphans:2;widows:2;text-align:left}li{color:#000000;font-size:11pt;font-family:"Calibri"}p{margin:0;color:#000000;font-size:11pt;font-family:"Calibri"}h1{padding-top:24pt;color:#000000;font-weight:700;font-size:24pt;padding-bottom:6pt;font-family:"Calibri";line-height:1.0791666666666666;page-break-after:avoid;orphans:2;widows:2;text-align:left}h2{padding-top:18pt;color:#000000;font-weight:700;font-size:18pt;padding-bottom:4pt;font-family:"Calibri";line-height:1.0791666666666666;page-break-after:avoid;orphans:2;widows:2;text-align:left}h3{padding-top:14pt;color:#000000;font-weight:700;font-size:14pt;padding-bottom:4pt;font-family:"Calibri";line-height:1.0791666666666666;page-break-after:avoid;orphans:2;widows:2;text-align:left}h4{padding-top:12pt;color:#000000;font-weight:700;font-size:12pt;padding-bottom:2pt;font-family:"Calibri";line-height:1.0791666666666666;page-break-after:avoid;orphans:2;widows:2;text-align:left}h5{padding-top:11pt;color:#000000;font-weight:700;font-size:11pt;padding-bottom:2pt;font-family:"Calibri";line-height:1.0791666666666666;page-break-after:avoid;orphans:2;widows:2;text-align:left}h6{padding-top:10pt;color:#000000;font-weight:700;font-size:10pt;padding-bottom:2pt;font-family:"Calibri";line-height:1.0791666666666666;page-break-after:avoid;orphans:2;widows:2;text-align:left}</style><style>
+  /* --- Layout overrides (added) --- */
+  html, body { height: 100%; }
+  body.doc-body {
+    margin: 0;
+    background: #ffffff;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .toolbar {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background: #ffffff;
+    border-bottom: 1px solid #e5e7eb;
+    height: 44px;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+  }
+  .toolbar-inner {
+    width: 100%;
+    max-width: 180mm;
+    margin: 0 auto;
+    padding: 0 12px;
+    display: flex;
+    justify-content: flex-end;
+    box-sizing: border-box;
+  }
+  .btn {
+    appearance: none;
+    border: 1px solid #d1d5db;
+    background: #ffffff;
+    border-radius: 8px;
+    padding: 8px 12px;
+    font: 600 13px/1 Arial, sans-serif;
+    cursor: pointer;
+  }
+  .btn:hover { background: #f9fafb; }
+  .btn:active { background: #f3f4f6; }
+  .btn:focus { outline: 2px solid #93c5fd; outline-offset: 2px; }
+
+  .experience-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+    padding: 4px 0;
+  }
+  .experience-title {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+  .experience-dates {
+    text-align: right;
+    white-space: nowrap;
+    font-weight: 700;
+  }
+
+
+  .page-container {
+    display: flex;
+    justify-content: center;
+    padding: 16px;
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 180mm;
+    margin: 0 auto;
+  }
+
+  /* Center the document and reduce excessive top padding */
+  .page.c22 {
+    margin: 0 auto;
+    width: 100%;
+    max-width: 180mm;
+    padding: 32px 48px 56px 48px !important;
+    box-sizing: border-box;
+  }
+
+  /* Prevent fixed-width images from overflowing */
+  .page img {
+    max-width: 100% !important;
+    height: auto !important;
+  }
+  /* --- Fix Google Docs exported horizontal line images --- */
+  .doc-content span[style*="overflow: hidden"][style*="display: inline-block"][style*="height:"] {
+    display: block !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    margin: 8px 0 10px 0 !important;
+    line-height: 0 !important;
+  }
+  .doc-content span[style*="overflow: hidden"][style*="display: inline-block"] img {
+    display: block;
+    width: 100% !important;
+    max-width: 100% !important;
+    height: auto !important;
+  }
+
+
+  /* Print / PDF */
+  @media print {
+    body.doc-body { background: #ffffff; }
+    .toolbar { display: none !important; }
+    .page-container { padding: 0 !important; }
+    .page.c22 {
+      box-shadow: none !important;
+      border-radius: 0 !important;
+      padding: 0 !important;
+      max-width: none !important;
+      width: auto !important;
+    }
+    @page { margin: 12mm; }
+  }
+</style>
+</head><body class="doc-body">
+  <header class="toolbar">
+    <div class="toolbar-inner">
+      <button id="downloadPdfBtn" class="btn" type="button">Download as PDF</button>
+    </div>
+  </header>
+
+  <div class="page-container">
+    <div class="page c18 c22 doc-content">
+<div><p class="c20 c25"><span class="c13 c27"></span></p></div><p class="c16"><span class="c6"><a class="c0" href="https://www.google.com/url?q=https://www.linkedin.com/in/timakhovich/&amp;sa=D&amp;source=editors&amp;ust=1767535999415161&amp;usg=AOvVaw1CpvsIJ-HO9pqomKat3NQL">Ivan TIMAKHOVICH</a></span><span class="c9">&nbsp;&mdash; Recruiter</span><span class="c23 c14">, Experience:</span><span class="c9 c14">&nbsp;</span><span class="c9 c35">4+</span><span class="c9 c14">&nbsp;years</span><span class="c14 c23">&nbsp;</span></p><p class="c16"><span class="c10">&nbsp;Alicante, Spain | </span><span class="c12 c10"><a class="c0" href="https://www.google.com/url?q=http://timahovich.com&amp;sa=D&amp;source=editors&amp;ust=1767535999415559&amp;usg=AOvVaw1R1yxUiSNW2fkuhBiwQlKP">timahovich.com</a></span><span class="c10">&nbsp;| </span><span class="c12 c10"><a class="c0" href="mailto:ivan@timahovich.com">ivan@timahovich.com</a></span><span class="c10">&nbsp;</span><span class="c10">| +34(670)293-674 &nbsp;| </span><span class="c10 c12"><a class="c0" href="https://www.google.com/url?q=http://t.me/timahovich&amp;sa=D&amp;source=editors&amp;ust=1767535999415948&amp;usg=AOvVaw1zgCPNMWuSlPJq1c4N0DlW">Telegram</a></span><span class="c10">&nbsp;| </span><span class="c12 c10"><a class="c0" href="https://www.google.com/url?q=https://wa.me/%2B34670293674&amp;sa=D&amp;source=editors&amp;ust=1767535999416090&amp;usg=AOvVaw0JspZj1BoCJwJHhDCC8Ga8">WhatsApp </a></span><span class="c12 c33"><a class="c0" href="https://www.google.com/url?q=http://t.me/Timahovichivan&amp;sa=D&amp;source=editors&amp;ust=1767535999416161&amp;usg=AOvVaw306zBWOe-N8_Eyot1-JD_U">&nbsp;</a></span></p><p class="c16"><span style="overflow: hidden; display: inline-block; margin: 0.00px 0.00px; border: 0.00px solid #000000; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px); width: 602.88px; height: 1.94px;"><img alt="" src="images/image2.png" style="width: 602.88px; height: 1.94px; margin-left: 0.00px; margin-top: 0.00px; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px);" title=""></span></p><p class="c16"><span class="c13 c9 c18">ABOUT</span></p><p class="c34"><span class="c10">Recruiting-focused professional with full-cycle hiring experience (in engineering, design, content and more) and strong stakeholder communication. Built broad technical literacy and developed work-fluent Spanish for day-to-day professional communication. Ready to support high-paced remote hiring at TripleTen.</span><span style="overflow: hidden; display: inline-block; margin: 0.00px 0.00px; border: 0.00px solid #000000; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px); width: 602.88px; height: 1.94px;"><img alt="" src="images/image2.png" style="width: 602.88px; height: 1.94px; margin-left: 0.00px; margin-top: 0.00px; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px);" title=""></span></p><p class="c16"><span class="c13 c9 c18">EXPERIENCE</span></p><div class="experience-header"><span class="experience-title"><span class="c5">Relocation, Upskilling and Internship at </span><span class="c12 c5"><a class="c0" href="https://www.google.com/url?q=https://yeahub.ru/&amp;sa=D&amp;source=editors&amp;ust=1767535999417324&amp;usg=AOvVaw0T7xcGUPhd5T--QsNgQF9X">YeaHub</a></span></span><span class="experience-dates c11">1/2025 &ndash; Current, 1 year</span></div><ul class="c3 lst-kix_list_1-0 start"><li class="c17 li-bullet-0"><span class="c10">Relocated to Spain and adapted to a new professional environment. Developed </span><span class="c2">Spanish to Fluent </span><span class="c10 c13">for day-to-day professional communication and structured calls.</span></li><li class="c17 li-bullet-0"><span class="c10">Built </span><span class="c2">practical technical literacy</span><span class="c13 c10">&nbsp;through a QA internship: backend, frontend, integration testing and issue tracking in Jira &mdash; enabling confident communication with engineers and stronger technical screening.</span></li></ul><p class="c1 c20"><span class="c13 c9"></span></p><div class="experience-header"><span class="experience-title"><span class="c15 c5"><a class="c0" href="https://www.google.com/url?q=https://www.linkedin.com/company/autotelic-council/&amp;sa=D&amp;source=editors&amp;ust=1767535999418458&amp;usg=AOvVaw3vPn8oyxcxIIg1wK3skGRm">Autotelic Council</a></span><span class="c2">&nbsp;Research &amp; Operations</span></span><span class="experience-dates c11">02/2024 &ndash; 12/2024, 11 months</span></div><p class="c1"><span class="c11 c29">Investment holding </span></p><ul class="c3 lst-kix_list_1-0"><li class="c17 li-bullet-0"><span class="c2">Guided onboarding</span><span class="c13 c10">&nbsp;for new team members by coordinating access/tool setup, aligning first-week expectations with stakeholders, and serving as the point of contact to ensure a smooth start.</span></li><li class="c17 li-bullet-0"><span class="c10">Partnered with internal stakeholders to</span><span class="c2">&nbsp;clarify requirements</span><span class="c10">, translate requests into written deliverables, and align priorities across workstreams, contributing, for example, to the development of an AI-powered LMS that reduced lecture time by </span><span class="c2">83.1%</span><span class="c13 c10">.</span></li></ul><p class="c1 c7"><span class="c13 c10"></span></p><div class="experience-header"><span class="experience-title"><span class="c5 c15"><a class="c0" href="https://www.google.com/url?q=https://stakewolle.com/&amp;sa=D&amp;source=editors&amp;ust=1767535999419817&amp;usg=AOvVaw2FhJbPHVJMsKH_SM_oSYJN">Stakewolle</a></span><span class="c2">&nbsp;Team Lead / Founding Ops &amp; Talent Partner</span></span><span class="experience-dates"><span class="c11">05/2022 &ndash; 01/2024, </span><span class="c4">1 year 8 months</span></span></div><p class="c1"><span class="c11 c29">Crypto startup</span></p><ul class="c3 lst-kix_list_2-0 start"><li class="c17 li-bullet-0"><span class="c11">Owned</span><span class="c5">&nbsp;end-to-end hiring</span><span class="c4">&nbsp;for a cross-functional team of 5.</span></li><li class="c17 li-bullet-0"><span class="c11">Built</span><span class="c5">&nbsp;multi-channel sourcing pipelines</span><span class="c4">&nbsp;(job boards, social media, partnerships with online schools), enabling rapid hiring to support product delivery milestones.</span></li><li class="c17 li-bullet-0"><span class="c11">Launched a </span><span class="c5">structured selection process</span><span class="c4">&nbsp;(screening criteria, interview loops, evaluation notes), improving decision speed and quality of hire in a small-team environment.</span></li><li class="c17 li-bullet-0"><span class="c11">Coordinated</span><span class="c5">&nbsp;interview scheduling </span><span class="c4">across time zones and stakeholders, managing calendars, reminders, and timely feedback collection.</span></li><li class="c17 li-bullet-0"><span class="c11">Managed </span><span class="c5">offer process</span><span class="c11">&nbsp;and acceptance. Coordinated </span><span class="c5">onboarding logistics </span><span class="c11">after acceptance (software access, accounts, first-week plan) to ensure a smooth start.<br></span></li></ul><p class="c21"><span class="c11 c29">New hires enabled a website rebuild and launch of gamification functionality, increasing the number of users by 13% in two months after launch.</span></p><p class="c1 c7"><span class="c13 c10"></span></p><div class="experience-header"><span class="experience-title"><span class="c15 c5"><a class="c0" href="https://www.google.com/url?q=https://en.itmo.ru/&amp;sa=D&amp;source=editors&amp;ust=1767535999422589&amp;usg=AOvVaw1rCRLliPf4V9f86J3QxNTY">ITMO University</a></span><span class="c2">&nbsp;Analyst</span></span><span class="experience-dates c11">02/2021 &ndash; 02/2022, 1 year</span></div><p class="c1"><span style="overflow: hidden; display: inline-block; margin: 0.00px 0.00px; border: 0.00px solid #000000; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px); width: 602.88px; height: 0.97px;"><img alt="" src="images/image1.png" style="width: 602.88px; height: 0.97px; margin-left: 0.00px; margin-top: 0.00px; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px);" title=""></span></p><p class="c16"><span class="c9 c18">EDUCATION</span></p><p class="c1"><span class="c15 c2"><a class="c0" href="https://www.google.com/url?q=https://en.itmo.ru/&amp;sa=D&amp;source=editors&amp;ust=1767535999423217&amp;usg=AOvVaw1h-xVjJi4jGUfq--YRDAcD">ITMO University</a></span><span class="c2">&nbsp;| </span><span class="c10">Bachelor&rsquo;s degree, Economics of a High-Tech Business. Top 40 graduates of the year.</span></p><p class="c1"><span class="c8">79th university in the world according to QS World University Rankings by Subject.</span></p><p class="c1 c20"><span class="c13 c19"></span></p><p class="c1"><span class="c15 c2"><a class="c0" href="https://www.google.com/url?q=https://www.edhec.edu/en&amp;sa=D&amp;source=editors&amp;ust=1767535999423800&amp;usg=AOvVaw2NRup9pzPSjzmxLgC_vEYE">EDHEC Business School</a></span><span class="c2">&nbsp;| </span><span class="c13 c10">Exchange Semester, International Business Administration.</span></p><p class="c1"><span class="c8">7th Business School in Europe, according to the Financial Times.</span><span style="overflow: hidden; display: inline-block; margin: 0.00px 0.00px; border: 0.00px solid #000000; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px); width: 602.88px; height: 1.94px;"><img alt="" src="images/image2.png" style="width: 602.88px; height: 1.94px; margin-left: 0.00px; margin-top: 0.00px; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px);" title=""></span></p><p class="c16"><span class="c32">&nbsp;</span><span class="c13 c18 c24">SKILLS</span></p><p class="c1"><span class="c2">Recruiting:</span><span class="c10">&nbsp;Sourcing (job boards, social media, partnerships), Candidate screening, Interview coordination, Structured evaluation/scorecards, Stakeholder alignment (hiring intake), Candidate communication.</span><span class="c13 c2">&nbsp;</span></p><p class="c1"><span class="c2">Software: </span><span class="c10">Confluence, Jira, Calendly, Monday.com, SharePoint, Notion, Trello, Google Docs/Sheets, Excel, Slack, ChatGPT, Claude, Cloudflare, MS Office, GitHub, AI Assistants, Postman, Swagger/OpenAPI, Figma. </span></p><p class="c1"><span class="c2">Languages: </span><span class="c10">English (Fluent, IELTS certification), Spanish (Work Fluent), Russian (Native)</span><span class="c2">.</span></p><div><p class="c25 c20"><span class="c13 c27"></span></p></div>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var btn = document.getElementById('downloadPdfBtn');
+      if (!btn) return;
+      btn.addEventListener('click', function () {
+        window.print();
+      });
+    })();
+  </script>
+</body></html>


### PR DESCRIPTION
### Motivation
- Provide a separate Russian-language entrypoint for the existing site while preventing public access to the original root page. 
- Preserve the full original site content under `/ru` so it remains available internally and via the new Russian entry.

### Description
- Copied the existing `index.html` into `ru/index.html` to keep the original site content available at `/ru/`.
- Replaced the repository root `index.html` with a lightweight Russian notice page that links to `/ru/` and informs visitors the main page is temporarily closed.
- Added simple responsive styling for the notice and kept the original site HTML unchanged inside `ru/index.html`.

### Testing
- Started a local static server with `python -m http.server 8000` and verified the site served the new root page successfully. 
- Ran a Playwright script which visited `http://127.0.0.1:8000/` and captured a screenshot (`artifacts/main-closed.png`), and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981d3f21998832eb9a3da693465353c)